### PR TITLE
Run tool plugins against all files at once when possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Process all Python source files at once with pylint tool plugin, instead of one pylint run per file. (#460)
 - Pin flake8<5 and pycodestyle<2.9.0 until <https://github.com/tholo/pytest-flake8/issues/87> is fixed.
 
 ## v0.3.1 - 2022-10-10

--- a/src/statick_tex/plugins/tool/chktex_tool_plugin.py
+++ b/src/statick_tex/plugins/tool/chktex_tool_plugin.py
@@ -34,29 +34,28 @@ class ChktexToolPlugin(ToolPlugin):  # type: ignore
         total_output: List[str] = []
 
         tool_bin: str = "chktex"
-        for src in files:
-            try:
-                subproc_args: List[str] = [tool_bin, src] + flags
-                output = subprocess.check_output(
-                    subproc_args, stderr=subprocess.STDOUT, universal_newlines=True
-                )
+        try:
+            subproc_args: List[str] = [tool_bin] + flags + files
+            output = subprocess.check_output(
+                subproc_args, stderr=subprocess.STDOUT, universal_newlines=True
+            )
 
-            except subprocess.CalledProcessError as ex:
-                # Return code 1 means "found problems".
-                # Return code 2 provides correct output with test cases used so far.
-                if ex.returncode not in (1, 2):
-                    logging.warning("Problem %s", ex.returncode)
-                    logging.warning("%s exception: %s", self.get_name(), ex.output)
-                    return None
-                output = ex.output
-
-            except OSError as ex:
-                logging.warning("Couldn't find %s! (%s)", tool_bin, ex)
+        except subprocess.CalledProcessError as ex:
+            # Return code 1 means "found problems".
+            # Return code 2 provides correct output with test cases used so far.
+            if ex.returncode not in (1, 2):
+                logging.warning("Problem %s", ex.returncode)
+                logging.warning("%s exception: %s", self.get_name(), ex.output)
                 return None
+            output = ex.output
 
-            logging.debug("%s", output)
+        except OSError as ex:
+            logging.warning("Couldn't find %s! (%s)", tool_bin, ex)
+            return None
 
-            total_output.append(output)
+        logging.debug("%s", output)
+
+        total_output.append(output)
 
         return total_output
 

--- a/src/statick_tex/plugins/tool/lacheck_tool_plugin.py
+++ b/src/statick_tex/plugins/tool/lacheck_tool_plugin.py
@@ -31,28 +31,27 @@ class LacheckToolPlugin(ToolPlugin):  # type: ignore
         total_output: List[str] = []
 
         tool_bin: str = "lacheck"
-        for src in files:
-            try:
-                subproc_args: List[str] = [tool_bin, src] + flags
-                output = subprocess.check_output(
-                    subproc_args, stderr=subprocess.STDOUT, universal_newlines=True
-                )
+        try:
+            subproc_args: List[str] = [tool_bin] + flags + files
+            output = subprocess.check_output(
+                subproc_args, stderr=subprocess.STDOUT, universal_newlines=True
+            )
 
-            except subprocess.CalledProcessError as ex:
-                # Return code 1 just means "found problems"
-                if ex.returncode != 1:
-                    logging.warning("Problem %d", ex.returncode)
-                    logging.warning("%s exception: %s", self.get_name(), ex.output)
-                    return None
-                output = ex.output
-
-            except OSError as ex:
-                logging.warning("Couldn't find %s! (%s)", tool_bin, ex)
+        except subprocess.CalledProcessError as ex:
+            # Return code 1 just means "found problems"
+            if ex.returncode != 1:
+                logging.warning("Problem %d", ex.returncode)
+                logging.warning("%s exception: %s", self.get_name(), ex.output)
                 return None
+            output = ex.output
 
-            logging.debug("%s", output)
+        except OSError as ex:
+            logging.warning("Couldn't find %s! (%s)", tool_bin, ex)
+            return None
 
-            total_output.append(output)
+        logging.debug("%s", output)
+
+        total_output.append(output)
 
         return total_output
 


### PR DESCRIPTION
Significantly speeds up many of the tool plugin runtime durations.