### PR TITLE
Remove codecov package from tox configuration.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ python =
 passenv = CI
 changedir = {toxinidir}/output-{envname}
 deps =
-    codecov
     flake8<5  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
     flake8-pep3101
     pycodestyle<2.9.0  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.


### PR DESCRIPTION
The package has been deprecated:
https://github.com/codecov/codecov-python

Discussion at:
https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259