### PR TITLE
Remove use of flake8.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,7 @@ envlist = py38, py39, py310, py311
 skip_missing_interpreters = true
 
 [pytest]
-flake8-max-line-length = 9000
 norecursedirs = .tox
-
-# To work with black some items must be ignored.
-# https://github.com/psf/black#how-black-wraps-lines
-[flake8]
-exclude = .tox
-ignore = E203, E231, W503
 
 # To work with black a specific configuration is required.
 # https://github.com/psf/black#how-black-wraps-lines
@@ -33,19 +26,16 @@ python =
 passenv = CI
 changedir = {toxinidir}/output-{envname}
 deps =
-    flake8<5  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
-    flake8-pep3101
-    pycodestyle<2.9.0  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
+    pycodestyle
     pydocstyle
     pytest
     pytest-cov
-    pytest-flake8
     pytest-isort
     .[test]
 commands =
     pydocstyle ../src/statick_tex/
     pycodestyle --ignore=E203,E501,W503 ../src/statick_tex/
-    pytest --flake8 --isort \
+    pytest --isort \
         --cov=statick_tool.plugins.discovery.tex_discovery_plugin \
         --cov=statick_tool.plugins.tool.chktex_tool_plugin \
         --cov=statick_tool.plugins.tool.lacheck_tool_plugin \


### PR DESCRIPTION
The flake8 project is marked as abandoned. There are some forks but none that do not cause unsolved issues for our code base.